### PR TITLE
Add Jest and test for login

### DIFF
--- a/__tests__/login.test.tsx
+++ b/__tests__/login.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LoginPage from '../pages/login';
+
+const push = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push }),
+}));
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    push.mockClear();
+  });
+
+  it('stores username and navigates on button click', () => {
+    render(<LoginPage />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Alice' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /continue to dashboard/i }));
+
+    expect(localStorage.getItem('username')).toBe('Alice');
+    expect(push).toHaveBeenCalledWith('/dashboard');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "foodapp",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@types/jest": "^29.5.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "next": "^13.4.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*"]
+}


### PR DESCRIPTION
## Summary
- set up Jest with TypeScript support and jsdom environment
- add sample tsconfig for testing
- add initial test covering login flow
- provide npm test script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848483652b8832c9c899a9aa246658e